### PR TITLE
feat: create `project` command that initializes a project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TurboCase
+# Turbo-Case
 
 ![turbocase-preview](assets/turbocase-preview.svg)
 
@@ -8,12 +8,14 @@
 Enable manual-test-case-as-code for [Testiny](https://www.testiny.io/).
 
 ## Table of contents
-- [TurboCase](#turbocase)
+- [Turbo-Case](#turbo-case)
   - [Table of contents](#table-of-contents)
   - [Installation](#installation)
+  - [Setup](#setup)
   - [Usage](#usage)
-    - [Creating a YAML test file](#creating-a-yaml-test-file)
-    - [Uploading test case to Testiny](#uploading-test-case-to-testiny)
+    - [Generating a test file](#generating-a-test-file)
+    - [Edit the YAML test file](#edit-the-yaml-test-file)
+    - [Uploading test cases to Testiny](#uploading-test-cases-to-testiny)
     - [Updating a test case](#updating-a-test-case)
     - [Reading a test case](#reading-a-test-case)
     - [Using the `upsert` command](#using-the-upsert-command)
@@ -38,62 +40,26 @@ Next, configure `turbocase` by running the following:
 ```shell
 turbocase config --api-key <YOUR_TESTINY_API_KEY>
 ```
+
+You can generate an Testiny API key by the following the instructions [here](https://app.testiny.io/settings/apikeys).
+
 ## Setup
 
-1. Structure your test management folder to look like this:
+1. Use `turbocase project <PROJ_NAME>` to initialize a test management project in the current directory.
+
+This command will automatically create the following folder structure:
+
 ```shell
-.
-├── _config.yaml
+path/to/project/project_name
+├── .project.toml
 └── app
-    ├── mobile-app
-    │   ├── android
-    │   │   └── android-only.yaml
-    │   └── iOS
-    │       └── ios-only.yaml
-    ├── new-test.yaml
-    └── web-app
-        └── only-web.yaml
+    ├── web
+    └── mobile
+        ├── android
+        └── ios
 ```
 
-> Focus on creating `_config.yaml` and the directories. The other Yamls are just for demonstration
-> We will add a `init` command later
-
-2. Map your Testiny projects in the `_config.yaml`
-```yaml
-Application: My App # decorative (optional)
-web-app: 1
-ios-app: 7
-android-app: 14
-```
-
-You can generate an API key using your corresponding tool: [Testiny](https://app.testiny.io/settings/apikeys)
-## Setup
-
-1. Structure your test management folder to look like this:
-```shell
-.
-├── _config.yaml
-└── app
-    ├── mobile-app
-    │   ├── android
-    │   │   └── android-only.yaml
-    │   └── iOS
-    │       └── ios-only.yaml
-    ├── new-test.yaml
-    └── web-app
-        └── only-web.yaml
-```
-
-> Focus on creating `_config.yaml` and the directories. The other Yamls are just for demonstration
-> We will add a `init` command later
-
-2. Map your Testiny projects in the `_config.yaml`
-```yaml
-Application: My App # decorative (optional)
-web-app: 1
-ios-app: 7
-android-app: 14
-```
+The `.project.toml` file contains the configuration of the project.
 
 ## Usage
 
@@ -120,9 +86,9 @@ expected results:
     - Success
 ```
 
-### Uploading test case to Testiny
+### Uploading test cases to Testiny
 
-A test case can be created and uploaded to [Testiny](https://www.testiny.io/) using the following:
+Test cases can be created and uploaded to [Testiny](https://www.testiny.io/) using the following:
 
 * Single file
 
@@ -141,7 +107,7 @@ turbocase create test_cases/*
 
 ### Updating a test case
 
-To update a test case, run the following:
+To update a specific test case, run the following:
 ```shell
 turbocase update --id 192 new_test_case.yaml
 ```

--- a/assets/turbocase-preview.svg
+++ b/assets/turbocase-preview.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 1238 416.0" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 1238 440.4" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,98 +19,102 @@
         font-weight: 700;
     }
 
-    .terminal-1501287954-matrix {
+    .terminal-1858226692-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-1501287954-title {
+    .terminal-1858226692-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-1501287954-r1 { fill: #ff8700 }
-.terminal-1501287954-r2 { fill: #c5c8c6 }
-.terminal-1501287954-r3 { fill: #d0b344;font-weight: bold }
-.terminal-1501287954-r4 { fill: #68a0b3 }
+    .terminal-1858226692-r1 { fill: #ff8700 }
+.terminal-1858226692-r2 { fill: #c5c8c6 }
+.terminal-1858226692-r3 { fill: #d0b344;font-weight: bold }
+.terminal-1858226692-r4 { fill: #68a0b3 }
     </style>
 
     <defs>
-    <clipPath id="terminal-1501287954-clip-terminal">
-      <rect x="0" y="0" width="1219.0" height="365.0" />
+    <clipPath id="terminal-1858226692-clip-terminal">
+      <rect x="0" y="0" width="1219.0" height="389.4" />
     </clipPath>
-    <clipPath id="terminal-1501287954-line-0">
+    <clipPath id="terminal-1858226692-line-0">
     <rect x="0" y="1.5" width="1220" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1501287954-line-1">
+<clipPath id="terminal-1858226692-line-1">
     <rect x="0" y="25.9" width="1220" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1501287954-line-2">
+<clipPath id="terminal-1858226692-line-2">
     <rect x="0" y="50.3" width="1220" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1501287954-line-3">
+<clipPath id="terminal-1858226692-line-3">
     <rect x="0" y="74.7" width="1220" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1501287954-line-4">
+<clipPath id="terminal-1858226692-line-4">
     <rect x="0" y="99.1" width="1220" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1501287954-line-5">
+<clipPath id="terminal-1858226692-line-5">
     <rect x="0" y="123.5" width="1220" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1501287954-line-6">
+<clipPath id="terminal-1858226692-line-6">
     <rect x="0" y="147.9" width="1220" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1501287954-line-7">
+<clipPath id="terminal-1858226692-line-7">
     <rect x="0" y="172.3" width="1220" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1501287954-line-8">
+<clipPath id="terminal-1858226692-line-8">
     <rect x="0" y="196.7" width="1220" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1501287954-line-9">
+<clipPath id="terminal-1858226692-line-9">
     <rect x="0" y="221.1" width="1220" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1501287954-line-10">
+<clipPath id="terminal-1858226692-line-10">
     <rect x="0" y="245.5" width="1220" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1501287954-line-11">
+<clipPath id="terminal-1858226692-line-11">
     <rect x="0" y="269.9" width="1220" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1501287954-line-12">
+<clipPath id="terminal-1858226692-line-12">
     <rect x="0" y="294.3" width="1220" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1501287954-line-13">
+<clipPath id="terminal-1858226692-line-13">
     <rect x="0" y="318.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1858226692-line-14">
+    <rect x="0" y="343.1" width="1220" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="414" rx="8"/>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="438.4" rx="8"/>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-1501287954-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1858226692-clip-terminal)">
     
-    <g class="terminal-1501287954-matrix">
-    <text class="terminal-1501287954-r1" x="0" y="20" textLength="73.2" clip-path="url(#terminal-1501287954-line-0)">Usage:</text><text class="terminal-1501287954-r3" x="85.4" y="20" textLength="109.8" clip-path="url(#terminal-1501287954-line-0)">turbocase</text><text class="terminal-1501287954-r2" x="195.2" y="20" textLength="24.4" clip-path="url(#terminal-1501287954-line-0)">&#160;[</text><text class="terminal-1501287954-r4" x="219.6" y="20" textLength="24.4" clip-path="url(#terminal-1501287954-line-0)">-h</text><text class="terminal-1501287954-r2" x="244" y="20" textLength="36.6" clip-path="url(#terminal-1501287954-line-0)">]&#160;[</text><text class="terminal-1501287954-r4" x="280.6" y="20" textLength="109.8" clip-path="url(#terminal-1501287954-line-0)">--version</text><text class="terminal-1501287954-r2" x="390.4" y="20" textLength="24.4" clip-path="url(#terminal-1501287954-line-0)">]&#160;</text><text class="terminal-1501287954-r4" x="414.8" y="20" textLength="109.8" clip-path="url(#terminal-1501287954-line-0)">&lt;command&gt;</text><text class="terminal-1501287954-r2" x="524.6" y="20" textLength="48.8" clip-path="url(#terminal-1501287954-line-0)">&#160;...</text><text class="terminal-1501287954-r2" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-1501287954-line-0)">
-</text><text class="terminal-1501287954-r2" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-1501287954-line-1)">
-</text><text class="terminal-1501287954-r2" x="0" y="68.8" textLength="744.2" clip-path="url(#terminal-1501287954-line-2)">Turbo-Case:&#160;a&#160;helper&#160;CLI&#160;App&#160;that&#160;enables&#160;manual-test-as-code</text><text class="terminal-1501287954-r2" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-1501287954-line-2)">
-</text><text class="terminal-1501287954-r2" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-1501287954-line-3)">
-</text><text class="terminal-1501287954-r1" x="0" y="117.6" textLength="97.6" clip-path="url(#terminal-1501287954-line-4)">Options:</text><text class="terminal-1501287954-r2" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-1501287954-line-4)">
-</text><text class="terminal-1501287954-r4" x="24.4" y="142" textLength="24.4" clip-path="url(#terminal-1501287954-line-5)">-h</text><text class="terminal-1501287954-r2" x="48.8" y="142" textLength="24.4" clip-path="url(#terminal-1501287954-line-5)">,&#160;</text><text class="terminal-1501287954-r4" x="73.2" y="142" textLength="73.2" clip-path="url(#terminal-1501287954-line-5)">--help</text><text class="terminal-1501287954-r2" x="170.8" y="142" textLength="109.8" clip-path="url(#terminal-1501287954-line-5)">Show&#160;help</text><text class="terminal-1501287954-r2" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-1501287954-line-5)">
-</text><text class="terminal-1501287954-r4" x="24.4" y="166.4" textLength="109.8" clip-path="url(#terminal-1501287954-line-6)">--version</text><text class="terminal-1501287954-r2" x="170.8" y="166.4" textLength="268.4" clip-path="url(#terminal-1501287954-line-6)">Show&#160;program&#x27;s&#160;version</text><text class="terminal-1501287954-r2" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-1501287954-line-6)">
-</text><text class="terminal-1501287954-r2" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-1501287954-line-7)">
-</text><text class="terminal-1501287954-r1" x="0" y="215.2" textLength="109.8" clip-path="url(#terminal-1501287954-line-8)">Commands:</text><text class="terminal-1501287954-r2" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-1501287954-line-8)">
-</text><text class="terminal-1501287954-r4" x="24.4" y="239.6" textLength="109.8" clip-path="url(#terminal-1501287954-line-9)">&lt;command&gt;</text><text class="terminal-1501287954-r2" x="170.8" y="239.6" textLength="61" clip-path="url(#terminal-1501287954-line-9)">Use&#160;`</text><text class="terminal-1501287954-r3" x="231.8" y="239.6" textLength="244" clip-path="url(#terminal-1501287954-line-9)">turbocase&#160;&lt;command&gt;&#160;</text><text class="terminal-1501287954-r3" x="475.8" y="239.6" textLength="73.2" clip-path="url(#terminal-1501287954-line-9)">--help</text><text class="terminal-1501287954-r2" x="549" y="239.6" textLength="268.4" clip-path="url(#terminal-1501287954-line-9)">`&#160;for&#160;more&#160;information</text><text class="terminal-1501287954-r2" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-1501287954-line-9)">
-</text><text class="terminal-1501287954-r4" x="48.8" y="264" textLength="73.2" clip-path="url(#terminal-1501287954-line-10)">config</text><text class="terminal-1501287954-r2" x="170.8" y="264" textLength="244" clip-path="url(#terminal-1501287954-line-10)">Configure&#160;Turbo-Case</text><text class="terminal-1501287954-r2" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-1501287954-line-10)">
-</text><text class="terminal-1501287954-r4" x="48.8" y="288.4" textLength="73.2" clip-path="url(#terminal-1501287954-line-11)">upsert</text><text class="terminal-1501287954-r2" x="170.8" y="288.4" textLength="902.8" clip-path="url(#terminal-1501287954-line-11)">Create&#160;a&#160;new&#160;test&#160;case&#160;or&#160;update&#160;an&#160;existing&#160;one&#160;(based&#160;on&#160;Title&#160;matching)</text><text class="terminal-1501287954-r2" x="1220" y="288.4" textLength="12.2" clip-path="url(#terminal-1501287954-line-11)">
-</text><text class="terminal-1501287954-r4" x="48.8" y="312.8" textLength="73.2" clip-path="url(#terminal-1501287954-line-12)">create</text><text class="terminal-1501287954-r2" x="170.8" y="312.8" textLength="402.6" clip-path="url(#terminal-1501287954-line-12)">Create&#160;test&#160;cases&#160;from&#160;YAML&#160;files</text><text class="terminal-1501287954-r2" x="1220" y="312.8" textLength="12.2" clip-path="url(#terminal-1501287954-line-12)">
-</text><text class="terminal-1501287954-r4" x="48.8" y="337.2" textLength="73.2" clip-path="url(#terminal-1501287954-line-13)">update</text><text class="terminal-1501287954-r2" x="170.8" y="337.2" textLength="634.4" clip-path="url(#terminal-1501287954-line-13)">Overwrite&#160;existing&#160;test&#160;cases&#160;(based&#160;on&#160;ID&#160;matching)</text><text class="terminal-1501287954-r2" x="1220" y="337.2" textLength="12.2" clip-path="url(#terminal-1501287954-line-13)">
-</text><text class="terminal-1501287954-r4" x="48.8" y="361.6" textLength="48.8" clip-path="url(#terminal-1501287954-line-14)">read</text><text class="terminal-1501287954-r2" x="170.8" y="361.6" textLength="475.8" clip-path="url(#terminal-1501287954-line-14)">Read&#160;existing&#160;test&#160;cases&#160;(search&#160;by&#160;ID)</text><text class="terminal-1501287954-r2" x="1220" y="361.6" textLength="12.2" clip-path="url(#terminal-1501287954-line-14)">
+    <g class="terminal-1858226692-matrix">
+    <text class="terminal-1858226692-r1" x="0" y="20" textLength="73.2" clip-path="url(#terminal-1858226692-line-0)">Usage:</text><text class="terminal-1858226692-r3" x="85.4" y="20" textLength="109.8" clip-path="url(#terminal-1858226692-line-0)">turbocase</text><text class="terminal-1858226692-r2" x="195.2" y="20" textLength="24.4" clip-path="url(#terminal-1858226692-line-0)">&#160;[</text><text class="terminal-1858226692-r4" x="219.6" y="20" textLength="24.4" clip-path="url(#terminal-1858226692-line-0)">-h</text><text class="terminal-1858226692-r2" x="244" y="20" textLength="36.6" clip-path="url(#terminal-1858226692-line-0)">]&#160;[</text><text class="terminal-1858226692-r4" x="280.6" y="20" textLength="109.8" clip-path="url(#terminal-1858226692-line-0)">--version</text><text class="terminal-1858226692-r2" x="390.4" y="20" textLength="24.4" clip-path="url(#terminal-1858226692-line-0)">]&#160;</text><text class="terminal-1858226692-r4" x="414.8" y="20" textLength="109.8" clip-path="url(#terminal-1858226692-line-0)">&lt;command&gt;</text><text class="terminal-1858226692-r2" x="524.6" y="20" textLength="48.8" clip-path="url(#terminal-1858226692-line-0)">&#160;...</text><text class="terminal-1858226692-r2" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-1858226692-line-0)">
+</text><text class="terminal-1858226692-r2" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-1858226692-line-1)">
+</text><text class="terminal-1858226692-r2" x="0" y="68.8" textLength="744.2" clip-path="url(#terminal-1858226692-line-2)">Turbo-Case:&#160;a&#160;helper&#160;CLI&#160;App&#160;that&#160;enables&#160;manual-test-as-code</text><text class="terminal-1858226692-r2" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-1858226692-line-2)">
+</text><text class="terminal-1858226692-r2" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-1858226692-line-3)">
+</text><text class="terminal-1858226692-r1" x="0" y="117.6" textLength="97.6" clip-path="url(#terminal-1858226692-line-4)">Options:</text><text class="terminal-1858226692-r2" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-1858226692-line-4)">
+</text><text class="terminal-1858226692-r4" x="24.4" y="142" textLength="24.4" clip-path="url(#terminal-1858226692-line-5)">-h</text><text class="terminal-1858226692-r2" x="48.8" y="142" textLength="24.4" clip-path="url(#terminal-1858226692-line-5)">,&#160;</text><text class="terminal-1858226692-r4" x="73.2" y="142" textLength="73.2" clip-path="url(#terminal-1858226692-line-5)">--help</text><text class="terminal-1858226692-r2" x="170.8" y="142" textLength="109.8" clip-path="url(#terminal-1858226692-line-5)">Show&#160;help</text><text class="terminal-1858226692-r2" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-1858226692-line-5)">
+</text><text class="terminal-1858226692-r4" x="24.4" y="166.4" textLength="109.8" clip-path="url(#terminal-1858226692-line-6)">--version</text><text class="terminal-1858226692-r2" x="170.8" y="166.4" textLength="268.4" clip-path="url(#terminal-1858226692-line-6)">Show&#160;program&#x27;s&#160;version</text><text class="terminal-1858226692-r2" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-1858226692-line-6)">
+</text><text class="terminal-1858226692-r2" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-1858226692-line-7)">
+</text><text class="terminal-1858226692-r1" x="0" y="215.2" textLength="109.8" clip-path="url(#terminal-1858226692-line-8)">Commands:</text><text class="terminal-1858226692-r2" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-1858226692-line-8)">
+</text><text class="terminal-1858226692-r4" x="24.4" y="239.6" textLength="109.8" clip-path="url(#terminal-1858226692-line-9)">&lt;command&gt;</text><text class="terminal-1858226692-r2" x="170.8" y="239.6" textLength="61" clip-path="url(#terminal-1858226692-line-9)">Use&#160;`</text><text class="terminal-1858226692-r3" x="231.8" y="239.6" textLength="244" clip-path="url(#terminal-1858226692-line-9)">turbocase&#160;&lt;command&gt;&#160;</text><text class="terminal-1858226692-r3" x="475.8" y="239.6" textLength="73.2" clip-path="url(#terminal-1858226692-line-9)">--help</text><text class="terminal-1858226692-r2" x="549" y="239.6" textLength="268.4" clip-path="url(#terminal-1858226692-line-9)">`&#160;for&#160;more&#160;information</text><text class="terminal-1858226692-r2" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-1858226692-line-9)">
+</text><text class="terminal-1858226692-r4" x="48.8" y="264" textLength="73.2" clip-path="url(#terminal-1858226692-line-10)">config</text><text class="terminal-1858226692-r2" x="170.8" y="264" textLength="244" clip-path="url(#terminal-1858226692-line-10)">Configure&#160;Turbo-Case</text><text class="terminal-1858226692-r2" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-1858226692-line-10)">
+</text><text class="terminal-1858226692-r4" x="48.8" y="288.4" textLength="85.4" clip-path="url(#terminal-1858226692-line-11)">project</text><text class="terminal-1858226692-r2" x="170.8" y="288.4" textLength="195.2" clip-path="url(#terminal-1858226692-line-11)">Initialize&#160;a&#160;new</text><text class="terminal-1858226692-r2" x="378.2" y="288.4" textLength="280.6" clip-path="url(#terminal-1858226692-line-11)">test&#160;management&#160;project</text><text class="terminal-1858226692-r2" x="1220" y="288.4" textLength="12.2" clip-path="url(#terminal-1858226692-line-11)">
+</text><text class="terminal-1858226692-r4" x="48.8" y="312.8" textLength="73.2" clip-path="url(#terminal-1858226692-line-12)">upsert</text><text class="terminal-1858226692-r2" x="170.8" y="312.8" textLength="902.8" clip-path="url(#terminal-1858226692-line-12)">Create&#160;a&#160;new&#160;test&#160;case&#160;or&#160;update&#160;an&#160;existing&#160;one&#160;(based&#160;on&#160;Title&#160;matching)</text><text class="terminal-1858226692-r2" x="1220" y="312.8" textLength="12.2" clip-path="url(#terminal-1858226692-line-12)">
+</text><text class="terminal-1858226692-r4" x="48.8" y="337.2" textLength="73.2" clip-path="url(#terminal-1858226692-line-13)">create</text><text class="terminal-1858226692-r2" x="170.8" y="337.2" textLength="402.6" clip-path="url(#terminal-1858226692-line-13)">Create&#160;test&#160;cases&#160;from&#160;YAML&#160;files</text><text class="terminal-1858226692-r2" x="1220" y="337.2" textLength="12.2" clip-path="url(#terminal-1858226692-line-13)">
+</text><text class="terminal-1858226692-r4" x="48.8" y="361.6" textLength="73.2" clip-path="url(#terminal-1858226692-line-14)">update</text><text class="terminal-1858226692-r2" x="170.8" y="361.6" textLength="634.4" clip-path="url(#terminal-1858226692-line-14)">Overwrite&#160;existing&#160;test&#160;cases&#160;(based&#160;on&#160;ID&#160;matching)</text><text class="terminal-1858226692-r2" x="1220" y="361.6" textLength="12.2" clip-path="url(#terminal-1858226692-line-14)">
+</text><text class="terminal-1858226692-r4" x="48.8" y="386" textLength="48.8" clip-path="url(#terminal-1858226692-line-15)">read</text><text class="terminal-1858226692-r2" x="170.8" y="386" textLength="475.8" clip-path="url(#terminal-1858226692-line-15)">Read&#160;existing&#160;test&#160;cases&#160;(search&#160;by&#160;ID)</text><text class="terminal-1858226692-r2" x="1220" y="386" textLength="12.2" clip-path="url(#terminal-1858226692-line-15)">
 </text>
     </g>
     </g>

--- a/turbocase/Testiny.py
+++ b/turbocase/Testiny.py
@@ -275,3 +275,33 @@ class Testiny:
             f"[cyan]Expected Results[/cyan]: \n{NEW_LINE.join(f'  - {line}' for line in test_case['expected_result_text'].split(NEW_LINE))}\n"
             f"[cyan]Project ID[/cyan]: {test_case['project_id']}"
         )
+
+    @staticmethod
+    def get_project_id(project_name: str) -> int | None:
+        """Gets the ID of a project by its name
+
+        Args:
+            project_name (str): The name of the project.
+
+        Returns:
+            int: The ID of the project if found or None if no project is found.
+        """
+        url = urljoin(Testiny.__API_URL, "project/find")
+        payload = json.dumps({"filter": {"name": project_name}, "idOnly": True})
+        headers = {
+            "Content-Type": Testiny.__CONTENT_TYPE,
+            "Accept": Testiny.__CONTENT_TYPE,
+            "X-Api-Key": get_configuration("api_key"),
+        }
+
+        response = requests.request(
+            "POST", url, headers=headers, data=payload, timeout=10
+        )
+        response.raise_for_status()
+
+        meta, data = response.json().values()
+
+        if meta["count"] == 0:
+            return None
+
+        return data[0]["id"]

--- a/turbocase/main.py
+++ b/turbocase/main.py
@@ -374,8 +374,8 @@ def add_project_command(subparsers: argparse._SubParsersAction):
     """
     project_parser = subparsers.add_parser(
         "project",
-        help="Initialize a new project",
-        description="Initialize a new project",
+        help="Initialize a new  test management project",
+        description="Initialize a new  test management project",
         add_help=False,
         formatter_class=RichHelpFormatter,
     )
@@ -429,15 +429,15 @@ def handle_project_command(args: argparse.Namespace, *, console: Console):
                     console.print(
                         f"[red]{FAILURE_PREFIX} No project found with the given name. Try again."
                     )
-            projects_ids[short_name] = project_id
+            projects_ids[short_name.lower()] = project_id
             console.print(
-                f"[green]{SUCCESS_PREFIX} Project found with ID: [yellow]`{projects_ids[short_name]}`[/yellow]."
+                f"[green]{SUCCESS_PREFIX} Project found with ID: [yellow]`{projects_ids[short_name.lower()]}`[/yellow]."
             )
             console.print()  # cosmetic
 
-        os.makedirs(os.path.join(project_path, "app/mobile/Android"), exist_ok=True)
-        os.makedirs(os.path.join(project_path, "app/mobile/iOS"), exist_ok=True)
-        os.makedirs(os.path.join(project_path, "app/Web"), exist_ok=True)
+        os.makedirs(os.path.join(project_path, "app/mobile/android"), exist_ok=True)
+        os.makedirs(os.path.join(project_path, "app/mobile/ios"), exist_ok=True)
+        os.makedirs(os.path.join(project_path, "app/web"), exist_ok=True)
 
         with open(os.path.join(project_path, ".project.toml"), "w") as project_file:
             toml.dump(projects_ids, project_file)


### PR DESCRIPTION
This command initializes a project by creating the below folder structure. The command will get the projects IDs by promting the user for the full projects names in Testiny, and then an API call will be made to get the project IDs. Note that I have made some changes to requirements in `README.md`. Eg: I am creating `.project.toml` instead of `_config.yaml` to be consistent with other parts of the project. I am also using slightly different folder names than the ones in the README.md. Also, most notably, I named the command `project` instead of `init`. However, those changes are minor and could be changed easily if needed.

PS: the requirements of the `README.md` are updated in this PR

```shell
path/to/project/project_name
├── .project.toml
└── app
    ├── web
    └── mobile
        ├── android
        └── ios
```
resolves #24