### PR TITLE
feat(generate): add the `generate` command to create test case templates

### DIFF
--- a/turbocase/Testiny.py
+++ b/turbocase/Testiny.py
@@ -305,3 +305,23 @@ class Testiny:
             return None
 
         return data[0]["id"]
+
+    @staticmethod
+    def generate_test_case_template(test_title: str) -> str:
+        """Generates a test case template with the given title.
+
+        Args:
+            test_title (str): The title of the test case.
+
+        Returns:
+            str: The generated test case template.
+        """
+        return (
+            f"title: {test_title}\n"
+            "preconditions:\n"
+            "  - \n"
+            "steps:\n"
+            "  - \n"
+            "expected results:\n"
+            "  - \n"
+        )


### PR DESCRIPTION
This command creates a test case template with the following form:

```yaml
title: test title
preconditions:
  -
steps:
  -
expected results:
  -
```

The user decides on the `app` that the test case belongs to. Eg:
web
android
ios
mobile (test belogs to both android and ios)
app (test belongs to all of above)

This choice affects the final destination of the template that's created.

Notes:
- The user is expected to run `turbocase project` before this command to initialize a project.
- A check is done to ensure the above.
- The user is guided if the check fails.
- A simple check is done to ensure the project structure is not corrupted.
- The user is also guided on how to fix the project structure if it is corrupted.
- Another check is done to ensure the uniqueness of the title of the test case.
- A FileExistsError is raised if the title is not unique.
- Lastly, the name of the test case yaml file is the title of the test case passed by the user in the CLI app.

resolves: #25